### PR TITLE
ci(ci): allow generated Dependabot squash titles

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -45,7 +45,7 @@ export default {
 		"scope-empty": [2, "never"],
 		"subject-case": [2, "never", ["upper-case", "pascal-case", "start-case"]],
 		"subject-full-stop": [2, "never", "."],
-		"header-max-length": [2, "always", 100],
+		"header-max-length": [2, "always", 120],
 		"body-max-line-length": [2, "always", 120],
 	},
 };


### PR DESCRIPTION
## Summary

- raise the commit header limit from 100 to 120 characters
- keep a hard upper bound while accepting GitHub-generated Dependabot squash titles

## Validation

- exact 118-character squash commit from PR #54: passes
- synthetic 121-character header: rejected
- pnpm lint: passes
- pre-commit lint and typecheck hooks: pass

Closes the push-only Commitlint failure from run #30349410756.