### PR TITLE
fix(oidc): bind explicit registration to validated trust chain

### DIFF
--- a/packages/oidc/src/registration/handler.ts
+++ b/packages/oidc/src/registration/handler.ts
@@ -301,6 +301,31 @@ export function createExplicitRegistrationHandler(
 			bestChain = chainResult.value;
 		}
 
+		// The request's embedded JWKS is sender-controlled and only proves possession
+		// of an arbitrary key. Bind the request to the validated federation identity
+		// by also verifying it with the leaf keys from the selected trust chain.
+		const trustedLeafJwks = bestChain.statements[0]?.payload.jwks;
+		if (!trustedLeafJwks || typeof trustedLeafJwks !== "object") {
+			return errorResponse(
+				403,
+				FederationErrorCode.InvalidTrustChain,
+				"Validated RP trust chain does not contain leaf JWKS",
+			);
+		}
+		const federationVerify = await verifyEntityStatement(ecJwt, trustedLeafJwks, {
+			...(config.options?.clock ? { clock: config.options.clock } : {}),
+			...(config.options?.clockSkewSeconds !== undefined
+				? { clockSkewSeconds: config.options.clockSkewSeconds }
+				: {}),
+		});
+		if (!federationVerify.ok) {
+			return errorResponse(
+				403,
+				FederationErrorCode.InvalidTrustChain,
+				"Request JWT is not signed by keys authorized by the validated RP trust chain",
+			);
+		}
+
 		let peerResolvedOpMetadata: Readonly<Record<string, unknown>> | undefined;
 		if (peerTrustChainHeader && peerTrustChainHeader.length > 0) {
 			const peerValidation = await validateSuppliedTrustChain(peerTrustChainHeader, trustAnchors, {

--- a/tests/tap/packages/oidc.ts
+++ b/tests/tap/packages/oidc.ts
@@ -4987,6 +4987,10 @@ export default (QUnit: QUnit) => {
 
 		async function createFederatedHandlerFixture(overrides?: HandlerConfigOverrides) {
 			const fed = await createMockFederation();
+			activeHandlerLeafKeys = {
+				privateKey: fed.leafSigningKey,
+				publicKey: fed.leafPublicKey as unknown as Record<string, unknown>,
+			};
 			const config = await createHandlerConfig({
 				trustAnchors: fed.trustAnchors,
 				options: fed.options,
@@ -4994,6 +4998,7 @@ export default (QUnit: QUnit) => {
 			});
 			return { config, fed };
 		}
+		let activeHandlerLeafKeys: { privateKey: JWK; publicKey: Record<string, unknown> } | undefined;
 
 		async function buildRegistrationRequest(
 			rpEntityId: string,
@@ -5001,7 +5006,10 @@ export default (QUnit: QUnit) => {
 			rpPrivateKey: JWK,
 			rpPublicKey: Record<string, unknown>,
 			overrides?: Record<string, unknown>,
+			useProvidedKeys = false,
 		) {
+			const signingKeys =
+				rpEntityId === LEAF_ID && !useProvidedKeys ? activeHandlerLeafKeys : undefined;
 			return signEntityStatement(
 				{
 					iss: rpEntityId,
@@ -5009,11 +5017,11 @@ export default (QUnit: QUnit) => {
 					aud: opEntityId,
 					iat: REG_NOW,
 					exp: REG_NOW + 3600,
-					jwks: { keys: [rpPublicKey] },
+					jwks: { keys: [signingKeys?.publicKey ?? rpPublicKey] },
 					...REQUIRED_FIELDS,
 					...overrides,
 				},
-				new JwkSigner(rpPrivateKey),
+				new JwkSigner(signingKeys?.privateKey ?? rpPrivateKey),
 				{ typ: JwtTyp.EntityStatement },
 			);
 		}
@@ -5060,6 +5068,37 @@ export default (QUnit: QUnit) => {
 				t.ok(payload.authority_hints);
 				t.true(Array.isArray(payload.authority_hints));
 				t.equal((payload.authority_hints as string[]).length, 1);
+			});
+
+			test("rejects a self-signed request not authorized by the RP trust chain", async (t) => {
+				const { config } = await createFederatedHandlerFixture();
+				const handler = createExplicitRegistrationHandler(config);
+				const attackerKeys = await generateSigningKey("ES256");
+				const jwt = await signEntityStatement(
+					{
+						iss: LEAF_ID,
+						sub: LEAF_ID,
+						aud: HANDLER_ENTITY_ID,
+						iat: REG_NOW,
+						exp: REG_NOW + 3600,
+						jwks: { keys: [attackerKeys.publicKey] },
+						...REQUIRED_FIELDS,
+					},
+					new JwkSigner(attackerKeys.privateKey),
+					{ typ: JwtTyp.EntityStatement },
+				);
+
+				const res = await handler(
+					new Request(`${HANDLER_ENTITY_ID}/federation_registration`, {
+						method: "POST",
+						headers: { "Content-Type": MediaType.EntityStatement },
+						body: jwt,
+					}),
+				);
+				t.equal(res.status, 403);
+				const body = (await res.json()) as Record<string, string>;
+				t.equal(body.error, FederationErrorCode.InvalidTrustChain);
+				t.ok(body.error_description?.includes("authorized"));
 			});
 
 			test("rejects request RP metadata with registration response fields", async (t) => {
@@ -5378,6 +5417,8 @@ export default (QUnit: QUnit) => {
 					HANDLER_ENTITY_ID as string,
 					wrongKeys.privateKey,
 					rpKeys.publicKey as unknown as Record<string, unknown>,
+					undefined,
+					true,
 				);
 				const res = await handler(
 					new Request(`${HANDLER_ENTITY_ID}/federation_registration`, {
@@ -5752,6 +5793,10 @@ export default (QUnit: QUnit) => {
 		module("oidc / createExplicitRegistrationHandler — trust chain resolution", () => {
 			test("resolves chain and sets trust_anchor, authority_hints, exp from chain", async (t) => {
 				const fed = await createMockFederation();
+				activeHandlerLeafKeys = {
+					privateKey: fed.leafSigningKey,
+					publicKey: fed.leafPublicKey as unknown as Record<string, unknown>,
+				};
 				const config = await createHandlerConfig({
 					trustAnchors: fed.trustAnchors,
 					options: fed.options,
@@ -5785,6 +5830,10 @@ export default (QUnit: QUnit) => {
 
 			test("returns 403 when no valid chain can be resolved for RP", async (t) => {
 				const fed = await createMockFederation();
+				activeHandlerLeafKeys = {
+					privateKey: fed.leafSigningKey,
+					publicKey: fed.leafPublicKey as unknown as Record<string, unknown>,
+				};
 				const config = await createHandlerConfig({
 					trustAnchors: fed.trustAnchors,
 					options: fed.options,
@@ -5814,6 +5863,10 @@ export default (QUnit: QUnit) => {
 
 			test("uses trust_chain JWT header when valid and present", async (t) => {
 				const fed = await createMockFederation();
+				activeHandlerLeafKeys = {
+					privateKey: fed.leafSigningKey,
+					publicKey: fed.leafPublicKey as unknown as Record<string, unknown>,
+				};
 				const config = await createHandlerConfig({
 					trustAnchors: fed.trustAnchors,
 					options: {
@@ -5857,6 +5910,10 @@ export default (QUnit: QUnit) => {
 
 			test("rejects invalid trust_chain JWT header instead of falling back to discovery", async (t) => {
 				const fed = await createMockFederation();
+				activeHandlerLeafKeys = {
+					privateKey: fed.leafSigningKey,
+					publicKey: fed.leafPublicKey as unknown as Record<string, unknown>,
+				};
 				const config = await createHandlerConfig({
 					trustAnchors: fed.trustAnchors,
 					options: fed.options,
@@ -5893,6 +5950,10 @@ export default (QUnit: QUnit) => {
 
 			test("invokes registrationProtocolAdapter.enrichResponseMetadata", async (t) => {
 				const fed = await createMockFederation();
+				activeHandlerLeafKeys = {
+					privateKey: fed.leafSigningKey,
+					publicKey: fed.leafPublicKey as unknown as Record<string, unknown>,
+				};
 				let enrichCalled = false;
 				const adapter: RegistrationProtocolAdapter = {
 					validateClientMetadata: (metadata) => ({ ok: true, value: metadata }),
@@ -5935,6 +5996,10 @@ export default (QUnit: QUnit) => {
 
 			test("emits client_secret when generateClientSecret hook returns a value", async (t) => {
 				const fed = await createMockFederation();
+				activeHandlerLeafKeys = {
+					privateKey: fed.leafSigningKey,
+					publicKey: fed.leafPublicKey as unknown as Record<string, unknown>,
+				};
 				let capturedClientSecret: string | undefined;
 				const config = await createHandlerConfig({
 					trustAnchors: fed.trustAnchors,
@@ -5973,6 +6038,10 @@ export default (QUnit: QUnit) => {
 
 			test("omits client_secret when hook returns undefined", async (t) => {
 				const fed = await createMockFederation();
+				activeHandlerLeafKeys = {
+					privateKey: fed.leafSigningKey,
+					publicKey: fed.leafPublicKey as unknown as Record<string, unknown>,
+				};
 				const config = await createHandlerConfig({
 					trustAnchors: fed.trustAnchors,
 					options: fed.options,
@@ -6008,6 +6077,10 @@ export default (QUnit: QUnit) => {
 		module("oidc / createExplicitRegistrationHandler — peer_trust_chain", () => {
 			async function buildPeerHandlerConfig(adapter?: RegistrationProtocolAdapter) {
 				const fed = await createMockFederation();
+				activeHandlerLeafKeys = {
+					privateKey: fed.leafSigningKey,
+					publicKey: fed.leafPublicKey as unknown as Record<string, unknown>,
+				};
 				const overrides: HandlerConfigOverrides = {
 					opEntityId: OP_ID,
 					trustAnchors: fed.trustAnchors,
@@ -6024,7 +6097,7 @@ export default (QUnit: QUnit) => {
 				peerTrustChain: string[];
 				includeRpTrustChain?: boolean;
 			}) {
-				const { fed, rpKeys, peerTrustChain, includeRpTrustChain = true } = opts;
+				const { fed, peerTrustChain, includeRpTrustChain = true } = opts;
 				const trustChain = includeRpTrustChain
 					? [fed.leafEcJwt, fed.taSubStatementForLeaf, fed.taEcJwt]
 					: undefined;
@@ -6035,10 +6108,12 @@ export default (QUnit: QUnit) => {
 						aud: OP_ID,
 						iat: REG_NOW,
 						exp: REG_NOW + 3600,
-						jwks: { keys: [rpKeys.publicKey as unknown as Record<string, unknown>] },
+						jwks: {
+							keys: [fed.leafPublicKey as unknown as Record<string, unknown>],
+						},
 						...REQUIRED_FIELDS,
 					},
-					new JwkSigner(rpKeys.privateKey),
+					new JwkSigner(fed.leafSigningKey),
 					{
 						typ: JwtTyp.EntityStatement,
 						extraHeaders: {
@@ -6233,7 +6308,6 @@ export default (QUnit: QUnit) => {
 			test("rejects peer_trust_chain rooted in a Trust Anchor not in the OP's trust set", async (t) => {
 				const { config, fed } = await buildPeerHandlerConfig();
 				const handler = createExplicitRegistrationHandler(config);
-				const rpKeys = await generateSigningKey("ES256");
 
 				const { privateKey: foreignTaKey, publicKey: foreignTaPub } =
 					await generateSigningKey("ES256");
@@ -6257,10 +6331,10 @@ export default (QUnit: QUnit) => {
 						aud: OP_ID,
 						iat: REG_NOW,
 						exp: REG_NOW + 3600,
-						jwks: { keys: [rpKeys.publicKey as unknown as Record<string, unknown>] },
+						jwks: { keys: [fed.leafPublicKey as unknown as Record<string, unknown>] },
 						...REQUIRED_FIELDS,
 					},
-					new JwkSigner(rpKeys.privateKey),
+					new JwkSigner(fed.leafSigningKey),
 					{
 						typ: JwtTyp.EntityStatement,
 						extraHeaders: { peer_trust_chain: [fed.opEcJwt, foreignTaEc] },
@@ -6290,7 +6364,6 @@ export default (QUnit: QUnit) => {
 				};
 				const { config, fed } = await buildPeerHandlerConfig(adapter);
 				const handler = createExplicitRegistrationHandler(config);
-				const rpKeys = await generateSigningKey("ES256");
 				const jwt = await signEntityStatement(
 					{
 						iss: LEAF_ID,
@@ -6298,16 +6371,15 @@ export default (QUnit: QUnit) => {
 						aud: OP_ID,
 						iat: REG_NOW,
 						exp: REG_NOW + 3600,
-						jwks: { keys: [rpKeys.publicKey as unknown as Record<string, unknown>] },
+						jwks: { keys: [fed.leafPublicKey as unknown as Record<string, unknown>] },
 						...REQUIRED_FIELDS,
 					},
-					new JwkSigner(rpKeys.privateKey),
+					new JwkSigner(fed.leafSigningKey),
 					{
 						typ: JwtTyp.EntityStatement,
 						extraHeaders: { peer_trust_chain: [] },
 					},
 				);
-				void fed;
 				const res = await handler(
 					new Request(`${OP_ID}/federation_registration`, {
 						method: "POST",


### PR DESCRIPTION
### Motivation

- Prevent OP from accepting attacker-controlled self-signed Entity Configuration (EC) JWTs that claim a trusted RP by requiring the submitted EC to be verifiable with keys authorized by the validated federation trust chain.

### Description

- Verify the submitted explicit registration JWT (`ecJwt`) not only against the request-embedded `jwks` but also against the leaf JWKS from the `bestChain` selected/validated for the claimed RP, returning `invalid_trust_chain` when the chain lacks leaf JWKS or the JWT is not signed by chain-authorized keys (changes in `packages/oidc/src/registration/handler.ts`).
- Add a regression test that rejects a self-signed request using attacker keys that claim a trusted RP entity, and update explicit-registration test fixtures to produce requests signed with federation-authorized leaf keys (changes in `tests/tap/packages/oidc.ts`).
- Adjust test helpers to enable testing both valid federation-authorized signatures and deliberately invalid/self-signed requests without changing existing coverage semantics.

### Testing

- Built packages with `pnpm -s build --filter=@oidfed/core --filter=@oidfed/oidc` and the builds completed successfully.
- Ran the full test suite with `pnpm -s tsx tests/tap/run-node.ts` which passed (1,618 tests reported passing after the change).
- Type checking with `pnpm typecheck` completed successfully and lint checks via `pnpm exec biome check --error-on-warnings packages/oidc/src/registration/handler.ts tests/tap/packages/oidc.ts` reported no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8047b8ac2c8331b19da8027a5da4a4)