### PR TITLE
fix(core): route trust-mark status POSTs through guarded `performFetch` to prevent SSRF

### DIFF
--- a/packages/core/src/trust-chain/fetch.ts
+++ b/packages/core/src/trust-chain/fetch.ts
@@ -286,6 +286,8 @@ export interface PerformFetchOptions extends FederationOptions {
 	 * inspects the response body header itself).
 	 */
 	expectedContentType?: string | null;
+	/** Request fields used by federation endpoints that do not use GET. */
+	request?: Pick<RequestInit, "method" | "headers" | "body">;
 }
 
 export async function performFetch(
@@ -300,6 +302,8 @@ export async function performFetch(
 	const accept = options?.accept ?? MediaType.EntityStatement;
 	const expectedContentType =
 		options?.expectedContentType !== undefined ? options.expectedContentType : accept;
+	const headers = new Headers(options?.request?.headers);
+	headers.set("Accept", accept);
 
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -322,10 +326,9 @@ export async function performFetch(
 
 	try {
 		const response = await fetchFn(url, {
+			...options?.request,
 			signal: controller.signal,
-			headers: {
-				Accept: accept,
-			},
+			headers,
 		});
 
 		clearTimeout(timer);

--- a/packages/core/src/trust-marks/fetch.ts
+++ b/packages/core/src/trust-marks/fetch.ts
@@ -6,7 +6,6 @@
  */
 import { FederationErrorCode, JwtTyp, MediaType, type TrustMarkStatus } from "../constants.js";
 import { err, type FederationError, federationError, ok, type Result } from "../errors.js";
-import { isExactContentType } from "../http.js";
 import { verifyEntityStatement } from "../jose/verify.js";
 import type { JWKSet } from "../schemas/jwk.js";
 import { performFetch } from "../trust-chain/fetch.js";
@@ -109,35 +108,19 @@ export async function fetchTrustMarkStatus(
 		);
 	}
 
-	const fetchFn = options?.httpClient ?? fetch;
 	const body = new URLSearchParams({ trust_mark: trustMarkJwt }).toString();
-	const response = await fetchFn(endpoint, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/x-www-form-urlencoded",
-			Accept: MediaType.TrustMarkStatusResponse,
+	const fetched = await performFetch(parsed.toString(), {
+		...options,
+		accept: MediaType.TrustMarkStatusResponse,
+		expectedContentType: MediaType.TrustMarkStatusResponse,
+		request: {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body,
 		},
-		body,
 	});
-	if (!response.ok) {
-		return err(
-			federationError(
-				FederationErrorCode.InvalidRequest,
-				`HTTP ${response.status} from trust mark status endpoint`,
-			),
-		);
-	}
-	const contentType = response.headers.get("content-type");
-	if (!isExactContentType(contentType, MediaType.TrustMarkStatusResponse)) {
-		const actual = contentType?.trim() || "<missing>";
-		return err(
-			federationError(
-				FederationErrorCode.InvalidRequest,
-				`Unexpected Content-Type '${actual}', expected '${MediaType.TrustMarkStatusResponse}'`,
-			),
-		);
-	}
-	const jwt = await response.text();
+	if (!fetched.ok) return fetched;
+	const jwt = fetched.value;
 
 	const verifyOpts: { expectedTyp: string; clockSkewSeconds?: number; clock?: Clock } = {
 		expectedTyp: JwtTyp.TrustMarkStatusResponse,

--- a/tests/tap/packages/core.ts
+++ b/tests/tap/packages/core.ts
@@ -7380,11 +7380,14 @@ export default (QUnit: QUnit) => {
 			test("happy path: POST returns status JWT (active)", async (t) => {
 				const signerKeys = await _genKey("ES256");
 				const responseJwt = await buildStatusResponseJwt("active", signerKeys);
-				const httpClient: HttpClient = async () =>
-					new Response(responseJwt, {
+				let requestInit: RequestInit | undefined;
+				const httpClient: HttpClient = async (_url, init) => {
+					requestInit = init;
+					return new Response(responseJwt, {
 						status: 200,
 						headers: { "Content-Type": "application/trust-mark-status-response+jwt" },
 					});
+				};
 				const result = await fetchTrustMarkStatus(
 					"https://ta.example.com/federation_trust_mark_status",
 					"eyJ.original.jwt",
@@ -7396,6 +7399,43 @@ export default (QUnit: QUnit) => {
 					t.equal(result.value.status, "active");
 					t.equal(result.value.issuer, "https://ta.example.com");
 				}
+				t.equal(requestInit?.method, "POST");
+				t.equal(requestInit?.body, "trust_mark=eyJ.original.jwt");
+				t.true(requestInit?.signal instanceof AbortSignal);
+				const headers = new Headers(requestInit?.headers);
+				t.equal(headers.get("content-type"), "application/x-www-form-urlencoded");
+				t.equal(headers.get("accept"), MediaType.TrustMarkStatusResponse);
+			});
+
+			test("applies federation SSRF and response-size controls", async (t) => {
+				const signerKeys = await _genKey("ES256");
+				let fetchCalls = 0;
+				const httpClient: HttpClient = async () => {
+					fetchCalls++;
+					return new Response("oversized", {
+						status: 200,
+						headers: { "Content-Type": MediaType.TrustMarkStatusResponse },
+					});
+				};
+
+				const blocked = await fetchTrustMarkStatus(
+					"https://127.0.0.1/private/status",
+					"eyJ.original.jwt",
+					{ keys: [signerKeys.publicKey] },
+					{ httpClient },
+				);
+				t.true(isErr(blocked));
+				t.equal(fetchCalls, 0);
+
+				const oversized = await fetchTrustMarkStatus(
+					"https://status.example.com/status",
+					"eyJ.original.jwt",
+					{ keys: [signerKeys.publicKey] },
+					{ httpClient, allowedHosts: ["status.example.com"], maxResponseBytes: 1 },
+				);
+				t.true(isErr(oversized));
+				if (isErr(oversized)) t.true(oversized.error.description.includes("too large"));
+				t.equal(fetchCalls, 1);
 			});
 
 			test("returns expired status pass-through", async (t) => {


### PR DESCRIPTION
### Motivation

- `fetchTrustMarkStatus` previously performed a direct `POST` with `fetch`, which validated only basic URL syntax and thus bypassed the repository's centralized SSRF and resource controls.

### Description

- Add a `request` field to `PerformFetchOptions` and extend `performFetch` to accept non-GET request fields and to apply `Accept` headers, timeout/`AbortSignal` propagation, host/CIDR validation, and response-size/content-type enforcement when making requests.
- Replace the direct `fetch` call in `fetchTrustMarkStatus` with `performFetch(parsed.toString(), ...)` and pass the form-encoded `body` plus `method` and `Content-Type` via the new `request` option while preserving response verification logic.
- Add regression tests in `tests/tap/packages/core.ts` that assert the POST `RequestInit` fields (method/body/headers), that a signal is provided, that SSRF blocking prevents disallowed hosts from invoking the HTTP client, and that response-size limits are enforced.

### Testing

- Ran lint/format checks with `pnpm exec biome check --write` on modified files and the workspace-wide checks required by commit hooks, which completed without issues.
- Ran type checks with `pnpm --filter @oidfed/core typecheck` and `pnpm exec tsc -p tests/tap/tsconfig.json --noEmit`, which succeeded with no errors.
- Built the monorepo and executed the TAP test suite via `pnpm build && pnpm quick:test`, and the full test run including the new tests passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a803eabaadc8331ac0c01e6acae6988)