### PR TITLE
fix(oidc): secure PAR endpoint requests

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -184,6 +184,8 @@ export { discoverEntity } from "./trust-chain/discovery.js";
 export {
 	fetchEntityConfiguration,
 	fetchSubordinateStatement,
+	type PerformFetchOptions,
+	performFetch,
 	validateEntityId,
 	validateFetchUrl,
 } from "./trust-chain/fetch.js";

--- a/packages/core/src/trust-chain/fetch.ts
+++ b/packages/core/src/trust-chain/fetch.ts
@@ -286,6 +286,10 @@ export interface PerformFetchOptions extends FederationOptions {
 	 * inspects the response body header itself).
 	 */
 	expectedContentType?: string | null;
+	/** Additional request fields for safe non-GET federation endpoint calls. */
+	requestInit?: Omit<RequestInit, "signal">;
+	/** Accepted HTTP statuses. Defaults to any successful (2xx) status. */
+	acceptedStatuses?: readonly number[];
 }
 
 export async function performFetch(
@@ -300,6 +304,8 @@ export async function performFetch(
 	const accept = options?.accept ?? MediaType.EntityStatement;
 	const expectedContentType =
 		options?.expectedContentType !== undefined ? options.expectedContentType : accept;
+	const headers = new Headers(options?.requestInit?.headers);
+	if (!headers.has("Accept")) headers.set("Accept", accept);
 
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -322,15 +328,16 @@ export async function performFetch(
 
 	try {
 		const response = await fetchFn(url, {
+			...options?.requestInit,
 			signal: controller.signal,
-			headers: {
-				Accept: accept,
-			},
+			headers,
 		});
 
 		clearTimeout(timer);
 
-		if (!response.ok) {
+		if (
+			options?.acceptedStatuses ? !options.acceptedStatuses.includes(response.status) : !response.ok
+		) {
 			return err({
 				code: InternalErrorCode.Network,
 				description: `HTTP ${response.status} from ${url}`,

--- a/packages/oidc/src/registration/automatic.ts
+++ b/packages/oidc/src/registration/automatic.ts
@@ -11,6 +11,7 @@ import {
 	type JwtSigner,
 	nowSeconds,
 	ok,
+	performFetch,
 	type Result,
 	resolveTrustChainForAnchor,
 	signEntityStatement,
@@ -308,7 +309,6 @@ export async function automaticRegistration(
 					),
 				);
 			}
-			const httpClient = options?.httpClient ?? fetch;
 			const clientAssertionSigner = rpConfig.protocolKeyProvider.getClientAssertionSigner
 				? await rpConfig.protocolKeyProvider.getClientAssertionSigner()
 				: requestObjectSigner;
@@ -340,23 +340,25 @@ export async function automaticRegistration(
 				client_assertion_type: CLIENT_ASSERTION_TYPE,
 				client_assertion: clientAssertion,
 			}).toString();
-			const response = await httpClient(parEndpoint, {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/x-www-form-urlencoded",
-					Accept: "application/json",
+			const parResponse = await performFetch(parEndpoint, {
+				...options,
+				accept: "application/json",
+				acceptedStatuses: [200, 201],
+				expectedContentType: "application/json",
+				requestInit: {
+					method: "POST",
+					redirect: "error",
+					headers: { "Content-Type": "application/x-www-form-urlencoded" },
+					body: formBody,
 				},
-				body: formBody,
 			});
-			if (response.status !== 201 && response.status !== 200) {
-				return err(
-					federationError(
-						InternalErrorCode.Network,
-						`PAR request failed (HTTP ${response.status})`,
-					),
-				);
+			if (!parResponse.ok) return err(parResponse.error);
+			let parPayload: Record<string, unknown>;
+			try {
+				parPayload = JSON.parse(parResponse.value) as Record<string, unknown>;
+			} catch {
+				return err(federationError(InternalErrorCode.Network, "PAR response is not valid JSON"));
 			}
-			const parPayload = (await response.json()) as Record<string, unknown>;
 			const parRequestUri = parPayload.request_uri;
 			const expiresIn = parPayload.expires_in;
 			if (typeof parRequestUri !== "string" || !parRequestUri.startsWith("urn:")) {

--- a/packages/oidc/src/schemas/metadata.ts
+++ b/packages/oidc/src/schemas/metadata.ts
@@ -300,7 +300,7 @@ export const OAuthAuthorizationServerMetadataSchema = z
 		// Device Authorization (RFC 8628)
 		device_authorization_endpoint: z.string().url().optional(),
 		// PAR (RFC 9126)
-		pushed_authorization_request_endpoint: z.string().url().optional(),
+		pushed_authorization_request_endpoint: httpsUrlNoFragment.optional(),
 		require_pushed_authorization_requests: z.boolean().optional(),
 		// DPoP (RFC 9449)
 		dpop_signing_alg_values_supported: z.array(z.string()).optional(),

--- a/tests/tap/packages/oidc.ts
+++ b/tests/tap/packages/oidc.ts
@@ -1986,6 +1986,40 @@ export default (QUnit: QUnit) => {
 				);
 			}
 		});
+
+		test("par: rejects an unsafe pushed_authorization_request_endpoint without posting", async (t) => {
+			const parEndpoint = "http://127.0.0.1/internal/par";
+			const fed = await createMockFederation({
+				opMetadata: {
+					openid_provider: {
+						issuer: OP_ID,
+						authorization_endpoint: `${OP_ID}/authorize`,
+						token_endpoint: `${OP_ID}/token`,
+						pushed_authorization_request_endpoint: parEndpoint,
+						response_types_supported: ["code"],
+						subject_types_supported: ["public"],
+						id_token_signing_alg_values_supported: ["ES256"],
+						client_registration_types_supported: ["automatic"],
+					},
+				},
+			});
+			const discovery = await createMockDiscovery(OP_ID, fed);
+			const { config } = await createRpConfig({ requestDelivery: "par" });
+			let parPosts = 0;
+			const httpClient: HttpClient = async (input, init) => {
+				const url = typeof input === "string" ? input : (input as Request).url;
+				if (url === parEndpoint) parPosts++;
+				return fed.options.httpClient!(input, init);
+			};
+
+			const result = await automaticRegistration(discovery, config, authzParams, fed.trustAnchors, {
+				...fed.options,
+				httpClient,
+			});
+			t.true(isErr(result));
+			if (isErr(result)) t.ok(result.error.description.includes("HTTPS"));
+			t.equal(parPosts, 0);
+		});
 	});
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- PAR delivery previously POSTed to the OP `pushed_authorization_request_endpoint` directly from OP metadata without URL validation, timeouts, content-type checks, or response-size limits, creating an SSRF/availability risk. 

### Description

- Route PAR POSTs through the repository's safe fetch helper by calling `performFetch` from `@oidfed/core` so `validateFetchUrl`, timeouts, response-size limits, and content-type checks are applied. 
- Extend `performFetch` with `requestInit` and `acceptedStatuses` options to support safe non-GET calls while preserving abort/timeouts, content-type validation, and bounded body reads. 
- Require an HTTPS-only, no-fragment PAR metadata value by tightening `pushed_authorization_request_endpoint` to `httpsUrlNoFragment` in the OIDC metadata schema. 
- Add a regression TAP test that advertises a loopback `http://127.0.0.1` PAR endpoint and asserts the library rejects the endpoint without issuing a POST. 

### Testing

- Ran repository static checks and linter: `pnpm exec biome check ...` and they passed. 
- Type-check and build: `pnpm --filter @oidfed/core typecheck`, `pnpm --filter @oidfed/core build`, and `pnpm --filter @oidfed/oidc typecheck` all completed successfully. 
- Full TAP suite executed with `pnpm exec tsx tests/tap/run-node.ts` and reported `1,618` tests passing with `0` failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8049e2ea748331bc53e45e12a512b2)