### PR TITLE
fix(authority): prevent extended-list claim signing amplification

### DIFF
--- a/packages/authority/src/endpoints/extended-list-claims.ts
+++ b/packages/authority/src/endpoints/extended-list-claims.ts
@@ -63,8 +63,9 @@ export async function extractClaims(
 ): Promise<Record<string, unknown>> {
 	const out: Record<string, unknown> = {};
 	for (const claim of requestedClaims) {
+		if (!Object.hasOwn(EXTENDED_LIST_CLAIM_EXTRACTORS, claim)) continue;
 		const extractor = EXTENDED_LIST_CLAIM_EXTRACTORS[claim];
-		if (!extractor) continue;
+		if (typeof extractor !== "function") continue;
 		const value = await extractor(record, ctx, now);
 		if (value !== undefined) out[claim] = value;
 	}

--- a/packages/authority/src/endpoints/extended-list.ts
+++ b/packages/authority/src/endpoints/extended-list.ts
@@ -84,14 +84,14 @@ function parseBooleanQuery(value: string | null): boolean | null | undefined {
  */
 function parseClaimsParam(params: URLSearchParams): string[] {
 	const raw = params.getAll("claims");
-	const out: string[] = [];
+	const out = new Set<string>();
 	for (const value of raw) {
 		for (const token of value.split(",")) {
 			const trimmed = token.trim();
-			if (trimmed.length > 0) out.push(trimmed);
+			if (trimmed.length > 0) out.add(trimmed);
 		}
 	}
-	return out;
+	return [...out];
 }
 
 export function createExtendedListHandler(

--- a/tests/tap/packages/authority.ts
+++ b/tests/tap/packages/authority.ts
@@ -1927,6 +1927,48 @@ export default (QUnit: QUnit) => {
 				t.deepEqual(commaBody, repeatedBody);
 			});
 
+			test("deduplicates repeated claims before extracting them", async (t) => {
+				const { ctx, subordinates, keyProvider } = await createTestContext();
+				await subordinates.add(makeXListRecord(XLIST_SUB_A));
+				let signingKeyLookups = 0;
+				const countedKeyProvider = new Proxy(keyProvider, {
+					get(target, property, receiver) {
+						if (property !== "getFederationKeySet") return Reflect.get(target, property, receiver);
+						return async () => {
+							signingKeyLookups++;
+							return keyProvider.getFederationKeySet();
+						};
+					},
+				});
+				const handler = createExtendedListHandler({
+					...ctx,
+					keyProvider: countedKeyProvider,
+				});
+				const res = await handler(
+					new Request(
+						`${XLIST_BASE_URL}?claims=subordinate_statement,subordinate_statement&claims=subordinate_statement`,
+					),
+				);
+
+				t.equal(res.status, 200);
+				t.equal(signingKeyLookups, 1, "signs each subordinate statement only once");
+			});
+
+			test("ignores claim names inherited from Object.prototype", async (t) => {
+				const { ctx, subordinates } = await createTestContext();
+				await subordinates.add(makeXListRecord(XLIST_SUB_A));
+				const handler = createExtendedListHandler(ctx);
+				const res = await handler(
+					new Request(`${XLIST_BASE_URL}?claims=__proto__,constructor,toString`),
+				);
+				const body = (await res.json()) as {
+					immediate_subordinate_entities: Array<Record<string, unknown>>;
+				};
+
+				t.equal(res.status, 200);
+				t.deepEqual(body.immediate_subordinate_entities[0], { id: XLIST_SUB_A });
+			});
+
 			test("comma syntax tolerates empty tokens", async (t) => {
 				const { ctx, subordinates } = await createTestContext();
 				await subordinates.add(makeXListRecord(XLIST_SUB_A));


### PR DESCRIPTION
### Motivation

- The extended-list handler accepted repeated or comma-separated `claims` tokens without deduplication and invoked extractors for every occurrence, allowing an attacker to amplify expensive operations (notably `subordinate_statement` signing) by repeating the same claim name.
- The extractor lookup also indexed the extractor registry without verifying it was an own, callable property, making prototype-inherited names (e.g. `__proto__`, `constructor`) leak through or cause errors.

### Description

- Deduplicate parsed `claims` tokens by switching `parseClaimsParam` to accumulate names in a `Set` and return a stable array, preserving first-seen semantics (`packages/authority/src/endpoints/extended-list.ts`).
- Harden extractor resolution by skipping non-own properties and non-callable registry entries using `Object.hasOwn` and `typeof extractor === "function"` (`packages/authority/src/endpoints/extended-list-claims.ts`).
- Add regression tests that assert repeated `subordinate_statement` claims only trigger a single signing-key lookup per subordinate and that prototype-inherited claim names are ignored (`tests/tap/packages/authority.ts`).
- Modified files: `packages/authority/src/endpoints/extended-list.ts`, `packages/authority/src/endpoints/extended-list-claims.ts`, `tests/tap/packages/authority.ts`.

### Testing

- Ran static checks on changed files with `pnpm exec biome check packages/authority/src/endpoints/extended-list.ts packages/authority/src/endpoints/extended-list-claims.ts tests/tap/packages/authority.ts`, which passed.
- Built core and typechecked authority with `pnpm --filter @oidfed/core build` and `pnpm --filter @oidfed/authority typecheck`, both succeeding.
- Ran the test suite with `pnpm quick:test`, which completed successfully (TAP: 1,619 tests passed; CLI tests: 132 passed), and the authority package tests including the new regressions passed.
- Lint and repository typechecks executed as part of the test flow and reported no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a804b794d488331acf23a5211399106)