### PR TITLE
fix(core): bound extended list response reads

### DIFF
--- a/packages/core/src/federation-api/extended-list.ts
+++ b/packages/core/src/federation-api/extended-list.ts
@@ -11,7 +11,7 @@ import {
 	MediaType,
 } from "../constants.js";
 import { err, type FederationError, federationError, ok, type Result } from "../errors.js";
-import { isExactContentType } from "../http.js";
+import { isExactContentType, readStreamWithLimit } from "../http.js";
 import {
 	type ExtendedListRequestParams,
 	type ExtendedListResponse,
@@ -89,15 +89,22 @@ function buildUrl(
 	return ok(url);
 }
 
-function readBody(response: Response, maxBytes: number): Promise<string> {
+async function readBody(
+	response: Response,
+	maxBytes: number,
+	signal: AbortSignal,
+): Promise<string> {
 	const contentLength = response.headers.get("content-length");
 	if (contentLength) {
 		const size = Number.parseInt(contentLength, 10);
 		if (Number.isFinite(size) && size > maxBytes) {
-			return Promise.resolve("");
+			throw new Error("Response too large");
 		}
 	}
-	return response.text();
+	if (!response.body) throw new Error("Empty response body");
+	const result = await readStreamWithLimit(response.body, maxBytes, signal);
+	if (!result.ok) throw new Error("Response too large");
+	return result.text;
 }
 
 /** Fetch the Extended Subordinate Listing endpoint and return the parsed response. */
@@ -156,17 +163,23 @@ export async function fetchExtendedSubordinatesList(
 			cause,
 		});
 	}
-	clearTimeout(timer);
-
 	const contentType = response.headers.get("content-type");
 
 	if (response.status === 400) {
 		let body = "";
 		try {
-			body = await readBody(response, maxBytes);
-		} catch {
+			body = await readBody(response, maxBytes, controller.signal);
+		} catch (cause) {
+			if (controller.signal.aborted) {
+				return err({
+					code: InternalErrorCode.Timeout,
+					description: `Request aborted or timed out: ${endpoint}`,
+					cause,
+				});
+			}
 			// fall through with empty body
 		}
+		clearTimeout(timer);
 		let code: string | undefined;
 		let description: string | undefined;
 		if (isExactContentType(contentType, MediaType.Json)) {
@@ -193,6 +206,7 @@ export async function fetchExtendedSubordinatesList(
 	}
 
 	if (!response.ok) {
+		clearTimeout(timer);
 		return err({
 			code: InternalErrorCode.Network,
 			description: `HTTP ${response.status} from ${endpoint}`,
@@ -200,6 +214,7 @@ export async function fetchExtendedSubordinatesList(
 	}
 
 	if (!isExactContentType(contentType, MediaType.Json)) {
+		clearTimeout(timer);
 		const actual = contentType?.trim() || "<missing>";
 		return err({
 			code: InternalErrorCode.Network,
@@ -209,14 +224,23 @@ export async function fetchExtendedSubordinatesList(
 
 	let body: string;
 	try {
-		body = await readBody(response, maxBytes);
+		body = await readBody(response, maxBytes, controller.signal);
 	} catch (cause) {
+		if (controller.signal.aborted) {
+			return err({
+				code: InternalErrorCode.Timeout,
+				description: `Request aborted or timed out: ${endpoint}`,
+				cause,
+			});
+		}
+		clearTimeout(timer);
 		return err({
 			code: InternalErrorCode.Network,
 			description: cause instanceof Error ? cause.message : `Failed to read response body`,
 			cause,
 		});
 	}
+	clearTimeout(timer);
 
 	let raw: unknown;
 	try {

--- a/packages/core/src/http.ts
+++ b/packages/core/src/http.ts
@@ -182,15 +182,31 @@ export async function extractRequestParams(request: Request): Promise<ExtractedR
 export async function readStreamWithLimit(
 	body: ReadableStream<Uint8Array>,
 	maxBytes: number,
+	signal?: AbortSignal,
 ): Promise<{ ok: true; text: string } | { ok: false }> {
 	const chunks: Uint8Array[] = [];
 	let received = 0;
-	for await (const chunk of body as AsyncIterable<Uint8Array>) {
-		received += chunk.length;
-		if (received > maxBytes) {
-			return { ok: false };
+	const reader = body.getReader();
+	const abort = () => {
+		void reader.cancel(signal?.reason);
+	};
+	signal?.addEventListener("abort", abort, { once: true });
+	if (signal?.aborted) abort();
+	try {
+		while (true) {
+			const { done, value: chunk } = await reader.read();
+			if (signal?.aborted) throw new DOMException("Aborted", "AbortError");
+			if (done) break;
+			received += chunk.length;
+			if (received > maxBytes) {
+				await reader.cancel();
+				return { ok: false };
+			}
+			chunks.push(chunk);
 		}
-		chunks.push(chunk);
+	} finally {
+		signal?.removeEventListener("abort", abort);
+		reader.releaseLock();
 	}
 	const buf = new Uint8Array(received);
 	let off = 0;

--- a/tests/tap/packages/core.ts
+++ b/tests/tap/packages/core.ts
@@ -12295,6 +12295,50 @@ export default (QUnit: QUnit) => {
 			}
 		});
 
+		test("rejects streamed responses exceeding maxResponseBytes", async (t) => {
+			let pulls = 0;
+			const body = new ReadableStream<Uint8Array>({
+				pull(controller) {
+					pulls++;
+					controller.enqueue(new Uint8Array(64));
+				},
+			});
+			const httpClient: HttpClient = async () =>
+				new Response(body, {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			const result = await fetchExtendedSubordinatesList(
+				"https://ta.example.com/federation_extended_list",
+				undefined,
+				{ httpClient, maxResponseBytes: 100 },
+			);
+			t.false(result.ok);
+			if (!result.ok) t.true(result.error.description.includes("Response too large"));
+			t.true(pulls < 4, "stops consuming the response after crossing the limit");
+		});
+
+		test("applies httpTimeoutMs while reading the response body", async (t) => {
+			const body = new ReadableStream<Uint8Array>({
+				async pull(controller) {
+					await new Promise((resolve) => setTimeout(resolve, 100));
+					controller.enqueue(new Uint8Array([32]));
+				},
+			});
+			const httpClient: HttpClient = async () =>
+				new Response(body, {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				});
+			const result = await fetchExtendedSubordinatesList(
+				"https://ta.example.com/federation_extended_list",
+				undefined,
+				{ httpClient, httpTimeoutMs: 10 },
+			);
+			t.false(result.ok);
+			if (!result.ok) t.equal(result.error.code, InternalErrorCode.Timeout);
+		});
+
 		test("respects an aborted AbortSignal", async (t) => {
 			const httpClient: HttpClient = async (_url, init) => {
 				if (init?.signal?.aborted) {


### PR DESCRIPTION
### Motivation

- The Extended Subordinate Listing helper previously used `response.text()` after only validating `Content-Length`, allowing chunked/compressed/understated responses to be fully buffered and bypass `maxResponseBytes` and the request timeout.
- This could lead to unbounded memory consumption or request-handler starvation when calling attacker-controlled federation endpoints.

### Description

- Replace the unbounded `response.text()` path with streaming reads that enforce the caller-configured `maxResponseBytes` by using the shared streaming core; add `AbortSignal` support to the stream reader to permit cancellation on timeout or explicit aborts (changes in `packages/core/src/http.ts`).
- Update `fetchExtendedSubordinatesList` to read response bodies via the bounded streaming helper and keep the HTTP timeout active while the body is consumed, mapping aborted reads to `InternalErrorCode.Timeout` and oversized reads to a network error with description `Response too large` (changes in `packages/core/src/federation-api/extended-list.ts`).
- Add regression tests to prove that streamed responses without `Content-Length` are stopped at `maxResponseBytes` and that `httpTimeoutMs` remains effective while reading slow bodies (changes in `tests/tap/packages/core.ts`).
- Minor cleanup: ensure the timeout is cleared for code paths that do not proceed to streaming reads.

### Testing

- Ran formatter/lint checks with `pnpm exec biome check` on the modified files and repo-wide checks; no blocking issues found.
- Ran static types with `pnpm typecheck` and the project typecheck tasks; typecheck succeeded.
- Ran the full TAP test suite via `pnpm exec tsx tests/tap/run-node.ts`, with all tests passing (1,619 tests passed), including the added regression tests for oversized and slow streamed bodies.
- Verified `git diff --check` and working tree cleanliness after applying the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a804b32e0e483318035f395afde0234)