### PR TITLE
fix(core): prevent prototype pollution when merging Immediate Superior metadata

### DIFF
--- a/packages/core/src/trust-chain/validate.ts
+++ b/packages/core/src/trust-chain/validate.ts
@@ -943,9 +943,14 @@ export async function validateTrustChain(
 			| undefined;
 		if (immSupMeta) {
 			for (const [entityType, params] of Object.entries(immSupMeta)) {
+				if (["__proto__", "prototype", "constructor"].includes(entityType)) continue;
+				if (!Object.hasOwn(metadata, entityType)) continue;
 				const existingMetadata = metadata[entityType];
 				if (!existingMetadata) continue;
-				Object.assign(existingMetadata, params as Record<string, unknown>);
+				for (const [key, value] of Object.entries(params as Record<string, unknown>)) {
+					if (["__proto__", "prototype", "constructor"].includes(key)) continue;
+					existingMetadata[key] = value;
+				}
 			}
 		}
 	}

--- a/tests/tap/packages/core.ts
+++ b/tests/tap/packages/core.ts
@@ -11612,6 +11612,35 @@ export default (QUnit: QUnit) => {
 					"openid_relying_party" in (result.chain.resolvedMetadata as Record<string, unknown>),
 				);
 			});
+			test("does not allow Immediate Superior SS metadata to pollute object prototypes", async (t) => {
+				const taKeys = await generateSigningKey("ES256");
+				const leafKeys = await generateSigningKey("ES256");
+				const leafEc = await vt_signEC(
+					"https://leaf.example.com",
+					leafKeys.privateKey,
+					leafKeys.publicKey,
+					{ authority_hints: ["https://ta.example.com"] },
+				);
+				const maliciousMetadata = JSON.parse(
+					'{"__proto__":{"oidfedPrototypePolluted":true}}',
+				) as Record<string, Record<string, unknown>>;
+				const ss = await vt_signSS(
+					"https://ta.example.com",
+					"https://leaf.example.com",
+					taKeys.privateKey,
+					leafKeys.publicKey,
+					{ metadata: maliciousMetadata },
+				);
+				const taEc = await vt_signEC("https://ta.example.com", taKeys.privateKey, taKeys.publicKey);
+				const taSet: TrustAnchorSet = new Map([
+					["https://ta.example.com" as EntityId, { jwks: { keys: [taKeys.publicKey] } }],
+				]);
+
+				const result = await validateTrustChain([leafEc, ss, taEc], taSet, { verboseErrors: true });
+
+				t.true(result.valid);
+				t.false("oidfedPrototypePolluted" in {});
+			});
 			test("rejects chain statement with missing exp", async (t) => {
 				const jose = await import("jose");
 				const taKeys = await generateSigningKey("ES256");


### PR DESCRIPTION
### Motivation

- The Immediate Superior subordinate-statement metadata merge in `validateTrustChain` used ordinary object indexing and `Object.assign` with attacker-controlled entity-type names, allowing a JSON-owned `"__proto__"` key to pollute `Object.prototype` and persist attacker properties across requests.
- The intent is to harden the merge so federation-signed subordinate metadata cannot mutate global prototypes or introduce dangerous keys while preserving the spec-required merge semantics for legitimate entity types.

### Description

- In `packages/core/src/trust-chain/validate.ts` the Immediate Superior metadata merge now skips dangerous entity-type names (`"__proto__"`, `"prototype"`, `"constructor

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a804ea989348331a726f801051d9cbe)