### PR TITLE
Prevent prototype pollution in metadata policy handling

### DIFF
--- a/packages/core/src/metadata-policy/apply.ts
+++ b/packages/core/src/metadata-policy/apply.ts
@@ -7,6 +7,7 @@ import {
 	type MetadataPolicyOptions,
 	validateCustomOperators,
 } from "./custom-operators.js";
+import { hasOwn, isPrototypeKey } from "./safe-keys.js";
 
 export type { MetadataPolicyOptions };
 
@@ -26,28 +27,38 @@ export function applyMetadataPolicy(
 	);
 
 	const result = structuredClone(metadata) as Record<string, Record<string, unknown>>;
+	const metadataKeyError = findUnsafeMetadataKey(result);
+	if (metadataKeyError) return unsafeMetadataKey(metadataKeyError);
 
 	if (superiorMetadataOverride) {
 		for (const [entityType, params] of Object.entries(superiorMetadataOverride)) {
-			if (!result[entityType]) {
+			if (isPrototypeKey(entityType)) return unsafeMetadataKey(entityType);
+			if (!hasOwn(result, entityType)) {
 				result[entityType] = {};
 			}
 			const entityResult = result[entityType];
 			for (const [param, value] of Object.entries(params as Record<string, unknown>)) {
+				if (isPrototypeKey(param)) return unsafeMetadataKey(`${entityType}.${param}`);
 				if (entityResult) entityResult[param] = value;
 			}
 		}
 	}
 
 	for (const [entityType, paramPolicies] of Object.entries(policy)) {
-		if (!result[entityType]) {
+		if (isPrototypeKey(entityType)) return unsafeMetadataKey(entityType);
+		if (!hasOwn(result, entityType)) {
 			result[entityType] = {};
 		}
 		const entityMetadata = result[entityType] as Record<string, unknown>;
 
 		for (const [paramName, opEntries] of Object.entries(paramPolicies)) {
+			if (isPrototypeKey(paramName)) return unsafeMetadataKey(`${entityType}.${paramName}`);
+			const unsafeOperator = Object.keys(opEntries as Record<string, unknown>).find(isPrototypeKey);
+			if (unsafeOperator) {
+				return unsafeMetadataKey(`${entityType}.${paramName}.${unsafeOperator}`);
+			}
 			const sortedOps = Object.entries(opEntries as Record<string, unknown>)
-				.filter(([opName]) => lookup[opName] !== undefined)
+				.filter(([opName]) => hasOwn(lookup, opName))
 				.sort(([a], [b]) => (lookup[a]?.order ?? 0) - (lookup[b]?.order ?? 0));
 
 			// Scope is space-delimited in OIDC but operators expect arrays
@@ -89,6 +100,25 @@ export function applyMetadataPolicy(
 	}
 
 	return ok(result as FederationMetadata);
+}
+
+function findUnsafeMetadataKey(
+	metadata: Record<string, Record<string, unknown>>,
+): string | undefined {
+	for (const [entityType, params] of Object.entries(metadata)) {
+		if (isPrototypeKey(entityType)) return entityType;
+		for (const param of Object.keys(params)) {
+			if (isPrototypeKey(param)) return `${entityType}.${param}`;
+		}
+	}
+	return undefined;
+}
+
+function unsafeMetadataKey(path: string): Result<never, FederationError> {
+	return err({
+		code: InternalErrorCode.MetadataPolicyViolation,
+		description: `Metadata policy contains unsafe key '${path}'`,
+	});
 }
 
 export function normalizeScope(scope: string): string[] {

--- a/packages/core/src/metadata-policy/merge.ts
+++ b/packages/core/src/metadata-policy/merge.ts
@@ -11,6 +11,7 @@ import {
 	validateCustomOperators,
 } from "./custom-operators.js";
 import { validateStandardPolicyOperatorConfiguration } from "./operators.js";
+import { hasOwn, isPrototypeKey } from "./safe-keys.js";
 
 const STANDARD_METADATA_POLICY_OPERATORS: ReadonlySet<string> = new Set(
 	Object.values(PolicyOperator),
@@ -51,7 +52,7 @@ export function resolveMetadataPolicy(
 				description: `metadata_policy_crit must not list standard metadata policy operator '${critOp}'`,
 			});
 		}
-		if (!lookup[critOp]) {
+		if (!hasOwn(lookup, critOp)) {
 			return err({
 				code: InternalErrorCode.MetadataPolicyError,
 				description: `Unknown critical metadata policy operator: '${critOp}'`,
@@ -72,19 +73,28 @@ export function resolveMetadataPolicy(
 		>;
 
 		for (const [entityType, paramPolicies] of Object.entries(clonedPolicy)) {
-			if (!merged[entityType]) {
+			if (isPrototypeKey(entityType)) {
+				return unsafePolicyKey(entityType);
+			}
+			if (!hasOwn(merged, entityType)) {
 				merged[entityType] = {};
 			}
 			const mergedEntityType = merged[entityType] as Record<string, Record<string, unknown>>;
 
 			for (const [paramName, opEntries] of Object.entries(paramPolicies)) {
-				if (!mergedEntityType[paramName]) {
+				if (isPrototypeKey(paramName)) {
+					return unsafePolicyKey(`${entityType}.${paramName}`);
+				}
+				if (!hasOwn(mergedEntityType, paramName)) {
 					mergedEntityType[paramName] = {};
 				}
 				const mergedParam = mergedEntityType[paramName] as Record<string, unknown>;
 
 				for (const [opName, opValue] of Object.entries(opEntries as Record<string, unknown>)) {
-					if (!lookup[opName]) continue;
+					if (isPrototypeKey(opName)) {
+						return unsafePolicyKey(`${entityType}.${paramName}.${opName}`);
+					}
+					if (!hasOwn(lookup, opName)) continue;
 
 					const opDef = lookup[opName] as PolicyOperatorDefinition;
 					const configError = validateStandardPolicyOperatorConfiguration(opName, opValue);
@@ -95,7 +105,7 @@ export function resolveMetadataPolicy(
 						});
 					}
 
-					if (mergedParam[opName] !== undefined) {
+					if (hasOwn(mergedParam, opName)) {
 						const mergeResult = opDef.merge(mergedParam[opName], opValue);
 						if (!mergeResult.ok) {
 							return err({
@@ -109,7 +119,7 @@ export function resolveMetadataPolicy(
 					}
 				}
 
-				const opNames = Object.keys(mergedParam).filter((k) => lookup[k] !== undefined);
+				const opNames = Object.keys(mergedParam).filter((k) => hasOwn(lookup, k));
 				for (let a = 0; a < opNames.length; a++) {
 					for (let b = a + 1; b < opNames.length; b++) {
 						const opA = opNames[a] as string;
@@ -132,4 +142,11 @@ export function resolveMetadataPolicy(
 	}
 
 	return ok(merged);
+}
+
+function unsafePolicyKey(path: string): Result<never, FederationError> {
+	return err({
+		code: InternalErrorCode.MetadataPolicyError,
+		description: `Metadata policy contains unsafe key '${path}'`,
+	});
 }

--- a/packages/core/src/metadata-policy/safe-keys.ts
+++ b/packages/core/src/metadata-policy/safe-keys.ts
@@ -1,0 +1,11 @@
+const PROTOTYPE_KEYS: ReadonlySet<string> = new Set(["__proto__", "constructor", "prototype"]);
+
+/** Returns whether an untrusted dictionary key can access JavaScript prototype state. */
+export function isPrototypeKey(key: string): boolean {
+	return PROTOTYPE_KEYS.has(key);
+}
+
+/** Own-property lookup for dictionaries whose keys can originate in federation data. */
+export function hasOwn(record: object, key: string): boolean {
+	return Object.hasOwn(record, key);
+}

--- a/tests/tap/packages/core.ts
+++ b/tests/tap/packages/core.ts
@@ -3235,6 +3235,22 @@ export default (QUnit: QUnit) => {
 	});
 
 	module("core / applyMetadataPolicy", () => {
+		test("rejects prototype-polluting metadata and policy keys", (t) => {
+			const maliciousMetadata = JSON.parse(
+				'{"__proto__":{"polluted":"metadata"}}',
+			) as FederationMetadata;
+			const maliciousPolicy = JSON.parse(
+				'{"__proto__":{"client_name":{"value":"policy"}}}',
+			) as Parameters<typeof applyMetadataPolicy>[1];
+			const maliciousOverride = JSON.parse(
+				'{"__proto__":{"polluted":"override"}}',
+			) as FederationMetadata;
+
+			t.false(applyMetadataPolicy(maliciousMetadata, {}).ok);
+			t.false(applyMetadataPolicy({ openid_relying_party: {} }, maliciousPolicy).ok);
+			t.false(applyMetadataPolicy({ openid_relying_party: {} }, {}, maliciousOverride).ok);
+			t.equal((Object.prototype as Record<string, unknown>).polluted, undefined);
+		});
 		test("returns metadata unchanged when policy is empty", (t) => {
 			const metadata: FederationMetadata = { openid_relying_party: { client_name: "Test RP" } };
 			const result = applyMetadataPolicy(metadata, {});
@@ -3784,6 +3800,15 @@ export default (QUnit: QUnit) => {
 		}
 
 		module("core / resolveMetadataPolicy", () => {
+			test("rejects prototype-polluting policy keys", (t) => {
+				const metadataPolicy = JSON.parse(
+					'{"__proto__":{"openid_relying_party":{"value":"polluted"}}}',
+				) as ParsedEntityStatement["payload"]["metadata_policy"];
+				const result = resolveMetadataPolicy([makeMergeStmt({ metadata_policy: metadataPolicy })]);
+
+				t.false(result.ok);
+				t.equal((Object.prototype as Record<string, unknown>).openid_relying_party, undefined);
+			});
 			test("returns empty policy when no statements have metadata_policy", (t) => {
 				const result = resolveMetadataPolicy([makeMergeStmt()]);
 				t.true(isOk(result));


### PR DESCRIPTION
### Motivation
- The metadata-policy merge and apply code used plain objects and unchecked dynamic keys, allowing attacker-controlled keys like `__proto__`, `constructor`, or `prototype` to mutate `Object.prototype` and enable prototype pollution during trust-chain resolution.

### Description
- Add `packages/core/src/metadata-policy/safe-keys.ts` with `isPrototypeKey` and `hasOwn` helpers to detect prototype-sensitive keys and perform safe own-property checks.
- Harden `resolveMetadataPolicy` (`packages/core/src/metadata-policy/merge.ts`) to reject prototype-sensitive `entityType`, `paramName`, and operator keys and to use `hasOwn` for dictionary lookups, returning a metadata-policy error on unsafe keys.
- Harden `applyMetadataPolicy` (`packages/core/src/metadata-policy/apply.ts`) to scan base metadata for unsafe keys, reject prototype-sensitive keys in superior overrides, policy parameter names, and operators, and to use `hasOwn` when consulting operator lookup tables, returning a metadata-policy violation on unsafe keys.
- Add regression tests in `tests/tap/packages/core.ts` that construct JSON `__proto__` payloads for metadata, policy, and superior overrides and assert the functions reject them and that `Object.prototype` remains unchanged.

### Testing
- Ran `pnpm exec biome check packages/core/src/metadata-policy/merge.ts packages/core/src/metadata-policy/apply.ts packages/core/src/metadata-policy/safe-keys.ts tests/tap/packages/core.ts` with no blocking errors.
- Ran `pnpm typecheck` successfully across the monorepo.
- Ran the full test suite with `pnpm exec tsx tests/tap/run-node.ts` and observed all tests pass (test run reported passing tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a804f63d2c48331b7bf57c8c12013ab)